### PR TITLE
Script to update list of IdP and small other fixes

### DIFF
--- a/Ib5c99e3b7b16bfb64b651d2129643d6f53fe7722.patch
+++ b/Ib5c99e3b7b16bfb64b651d2129643d6f53fe7722.patch
@@ -1,0 +1,31 @@
+diff -ruN openstack_auth/utils.py /usr/lib/python2.7/site-packages/openstack_auth/utils.py
+--- openstack_auth/utils.py	2015-08-18 10:46:28.760189473 +0200
++++ /usr/lib/python2.7/site-packages/openstack_auth/utils.py	2015-04-14 04:57:33.000000000 +0200
+@@ -183,15 +183,6 @@
+     return websso_enabled and keystonev3_plus
+ 
+ 
+-def build_absolute_uri(request, relative_url):
+-    """Ensure absolute_uri are relative to WEBROOT."""
+-    webroot = getattr(settings, 'WEBROOT', '')
+-    if webroot.endswith("/") and relative_url.startswith("/"):
+-        webroot = webroot[:-1]
+-
+-    return request.build_absolute_uri(webroot + relative_url)
+-
+-
+ def has_in_url_path(url, sub):
+     """Test if the `sub` string is in the `url` path."""
+     scheme, netloc, path, query, fragment = urlparse.urlsplit(url)
+diff -ruN openstack_auth/views.py /usr/lib/python2.7/site-packages/openstack_auth/views.py
+--- openstack_auth/views.py	2015-08-18 10:46:23.991189461 +0200
++++ /usr/lib/python2.7/site-packages/openstack_auth/views.py	2015-08-18 09:57:13.906181893 +0200
+@@ -60,7 +60,7 @@
+         protocol = request.POST.get('auth_type', 'credentials')
+         if utils.is_websso_enabled() and protocol != 'credentials':
+             region = request.POST.get('region')
+-            origin = utils.build_absolute_uri(request, '/auth/websso/')
++            origin = request.build_absolute_uri('auth/websso/')
+             url = ('%s/auth/OS-FEDERATION/websso/%s?origin=%s' %
+                    (region, protocol, origin))
+             return shortcuts.redirect(url)

--- a/README.md
+++ b/README.md
@@ -142,8 +142,15 @@ This configuration consist on adding ``sessionHook="/regsite"`` to the ``Applica
 
 
 ### OpenStack keystone and horizon configuration
-To propertly configure keystone and horizon components of OpenStack to work correctly with federated access and with the regsite described in this projects,
-the following configurations need to be done.
+To propertly configure keystone and horizon components of OpenStack to work correctly with federated access and with the regsite described in this projects, the following configurations need to be done.a
+
+Firstly the ``openstack/django_openstack_auth`` project must be of a verion including the patch to the change id Change-Id: Ib5c99e3b7b16bfb64b651d2129643d6f53fe7722
+(more information on it can be found [on the official openstack review site](https://review.openstack.org/#/c/173669/).
+If he version of the project does not include this patch, it must be applied by hand with the followin commands:
+```sh
+$ cd /usr/lib/python2.7/site-packages/openstack_auth
+$ patch -p1 < /opt/openstack-horizon-shibboleth/Ib5c99e3b7b16bfb64b651d2129643d6f53fe7722.patch
+```
 
 The file ``/etc/keystone/keystone.conf`` must be modified as follows (only modified parts presented, all the rest of the file remains untouched):
 ```ini
@@ -168,7 +175,7 @@ sso_callback_template = /etc/keystone/sso_callback_template.html
 enable=True
 ```
 
-Thenk the following commands needs to be executed to create the right structures inside keystone via the JSON API:
+Then the following commands needs to be executed to create the right structures inside keystone via the JSON API:
 ```sh
 #!/bin/bash
 OS_AUTH_URL='https://os.server.name:5000/v3'

--- a/README.md
+++ b/README.md
@@ -70,30 +70,64 @@ USER_ACCEPT_CREATION = True                                # Flag indicating wet
 
 ### Apache configuration
 You must protect the Horizon page with Shibboleth, you also have to specify the configuration of ``mod_wsgi`` to operate the django application.
+Usually the SP configuration for this regsite must be shared with the configuration for Keystone. For this reason the configuration of regsite usually happens
+in the samle file where the keystone webapplication is configured within Apache.
+
 Here an example of configuration for Apache:
 ```apache
-Alias /static /opt/openstack-horizon-shibboleth/openstack_regsite/static
+<VirtualHost *:5000>
+    SSLEngine on
+    SSLProtocol all -SSLv2
+    SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
+    SSLCertificateFile /etc/httpd/ssl/os-test.mi.garr.it.crt
+    SSLCertificateKeyFile /etc/httpd/ssl/os-test.mi.garr.it.key
+    SSLCertificateChainFile /etc/httpd/ssl/CA_GARR_MI.pem
 
-<Directory /opt/openstack-horizon-shibboleth/openstack_regsite/static>
+    <Location /Shibboleth.sso>
+        SetHandler shib
+    </Location>
+
+    Alias /regsite/static /opt/openstack-horizon-shibboleth/openstack_regsite/static
+
+    <Directory /opt/openstack-horizon-shibboleth/openstack_regsite/static>
         Require all granted
-</Directory>
+    </Directory>
 
-WSGIDaemonProcess openstack home=/opt/openstack-horizon-shibboleth/openstack_regsite
-WSGIProcessGroup openstack
+    WSGIDaemonProcess regsite home=/opt/openstack-horizon-shibboleth/openstack_regsite
+    WSGIProcessGroup regsite
+    WSGIPassAuthorization Off
+    WSGIScriptAlias /regsite /opt/openstack-horizon-shibboleth/openstack_regsite/wsgi.py
 
-WSGIScriptAlias / /opt/openstack-horizon-shibboleth/openstack_regsite/wsgi.py
-
-<Directory /opt/openstack-horizon-shibboleth/openstack_regsite>
+    <Directory /opt/openstack-horizon-shibboleth/openstack_regsite>
         Options all
         AllowOverride all
         Require all granted
-</Directory>
+    </Directory>
 
-<Location /shib_hook >
+    <Location /regsite>
         authtype shibboleth
         shibRequestSetting requireSession 1
         require valid-user
-</Location>
+    </Location>
+
+    WSGIDaemonProcess keystone-public processes=5 threads=1 user=keystone display-name=%{GROUP}
+    WSGIProcessGroup keystone-public
+    WSGIScriptAlias / /var/www/cgi-bin/keystone/main
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIPassAuthorization On
+    <IfVersion >= 2.4>
+      ErrorLogFormat "%{cu}t %M"
+    </IfVersion>
+    ErrorLog /var/log/httpd/keystone.log
+    CustomLog /var/log/httpd/keystone_access.log combined
+
+    <Location /v3/auth/OS-FEDERATION/websso/saml2>
+        authtype shibboleth
+        shibRequestSetting requireSession 1
+        require valid-user
+    </Location>
+
+</VirtualHost>
 ```
 
 ### Shibboleth configuration
@@ -105,3 +139,79 @@ If no entitlement or eppn provided the user can't login.
 
 The Shibboleth SP must also be configured to invoke the post login hook that creates users/projects on keystone.
 This configuration consist on adding ``sessionHook="/regsite"`` to the ``ApplicationDefaults`` tag of the ``/etc/shibboleth/shibboleth2.xml`` file.
+
+
+### OpenStack keystone and horizon configuration
+To propertly configure keystone and horizon components of OpenStack to work correctly with federated access and with the regsite described in this projects,
+the following configurations need to be done.
+
+The file ``/etc/keystone/keystone.conf`` must be modified as follows (only modified parts presented, all the rest of the file remains untouched):
+```ini
+[DEFAULT]
+...
+public_endpoint = https://os.server.name:5000
+
+[auth]
+...
+methods = external,password,token,oauth1,saml2
+saml2 = keystone.auth.plugins.mapped.Mapped
+
+[federation]
+...
+remote_id_attribute = 'Shib-Identity-Provider'
+remote_id_attribute = 'Shib-Identity-Provider'
+trusted_dashboard = https://os.server.name/dashboard/auth/websso/
+sso_callback_template = /etc/keystone/sso_callback_template.html
+
+[ssl]
+...
+enable=True
+```
+
+Thenk the following commands needs to be executed to create the right structures inside keystone via the JSON API:
+```sh
+#!/bin/bash
+OS_AUTH_URL='https://os.server.name:5000/v3'
+
+# Retrieve a token to be used for authentication.
+# The token-request.json file contains username/password for the admin user to authenticate with keystone.
+export TOKEN=`curl -si -d @token-request.json -H "Content-type: application/json" http://localhost:35357/v3/auth/tokens | awk '/X-Subject-Token/ {print $2}'`
+
+# IDs and constants to be used in curl scripts
+FEDERATION_ID='federationid'
+PROTOCOL_ID='saml2'
+MAPPING_ID='shib'
+ENTITY_IDS='"https://idp.mi.garr.it/idp/shibboleth"'
+
+# Register IdPs entityID in the federation module of keystone
+curl -si -H"X-Auth-Token:$TOKEN" -H "Content-type: application/json" -X PUT -d "{ \"identity_provider\": { \"description\": \"IdPs of the $FEDERATION_ID federation\", \"remote_ids\": [ $ENTITY_IDS ], \"enabled\": true } }" $OS_AUTH_URL/OS-FEDERATION/identity_providers/$FEDERATION_ID
+
+# Print identity_providers to see if everything's ok
+#curl -si -H"X-Auth-Token:$TOKEN" -H "Content-type: application/json" -X GET $OS_AUTH_URL/OS-FEDERATION/identity_providers
+
+# Add the protocol to manage SAML requests
+curl -si -H"X-Auth-Token:$TOKEN" -H "Content-type: application/json" -X PUT -d "{ \"protocol\": { \"mapping_id\": \"$MAPPING_ID\" } }" $OS_AUTH_URL/OS-FEDERATION/identity_providers/$FEDERATION_ID/protocols/$PROTOCOL_ID
+
+# Add the mapping
+curl -si -H"X-Auth-Token:$TOKEN" -H "Content-type: application/json" -X PUT -d "{ \"mapping\": { \"rules\": [ { \"local\": [ { \"user\": { \"domain\": { \"id\": \"default\" }, \"type\": \"local\", \"name\": \"{0}\" } } ], \"remote\": [ { \"type\": \"eppn\" } ] } ] } } " $OS_AUTH_URL/OS-FEDERATION/mappings/$MAPPING_ID
+```
+
+Lastly the ``/etc/openstack-dashboard/local_settings`` horizon config file must be edited as follows (only modified parts presented, all the rest of the file remains untouched):
+```ini
+OPENSTACK_KEYSTONE_URL = "https://os.server.name:5000/v3"
+...
+OPENSTACK_API_VERSIONS = {
+    "identity": 3,
+}
+
+# Enables keystone web single-sign-on if set to True.
+WEBSSO_ENABLED = True
+
+# Determines which authentication choice to show as default.
+WEBSSO_INITIAL_CHOICE = "saml2"
+
+WEBSSO_CHOICES = (
+    ("credentials", _("Keystone Credentials")),
+#    ("oidc", _("OpenID Connect")),
+    ("saml2", _("Security Assertion Markup Language"))) 
+```

--- a/openstack_regsite/openstack_dashboard/settings.py.example
+++ b/openstack_regsite/openstack_dashboard/settings.py.example
@@ -90,7 +90,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-VEVN_DIR = '/opt/openstack-horizon-shibboleth/regsite-venv'
+VENV_DIR = '/opt/openstack-horizon-shibboleth/regsite-venv'
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/

--- a/openstack_regsite/setup.py
+++ b/openstack_regsite/setup.py
@@ -26,7 +26,7 @@ setup(name='openstack_regsite',
       install_requires=[
           'Django>=1.7',
           'requests>=1.0.0',
-          'djangosaml2>=0.9.0',
+          #'djangosaml2>=0.9.0',
       ],
       entry_points="""
       # -*- Entry points: -*-

--- a/openstack_regsite/utils.py
+++ b/openstack_regsite/utils.py
@@ -130,7 +130,10 @@ def update_user(request):
     update_roles(request, user)
     email = request.META.get(mail_field, None)
 
-    if user.email != email:
+    try:
+        if user.email != email:
+            update_mail(user, email)
+    except AttributeError:
         update_mail(user, email)
 
     return user.name

--- a/openstack_regsite/wsgi.py
+++ b/openstack_regsite/wsgi.py
@@ -11,11 +11,12 @@ import os, sys
 current_directory = os.path.dirname(__file__)
 sys.path.append(current_directory)
 
-import settings
-activate_this = os.path.join('%s/bin/activate_this.py' % settings.VEVN_DIR)
-execfile(activate_this, dict(__file__=activate_this))
+from openstack_dashboard import settings
+if os.path.isdir('%s' % settings.VENV_DIR):
+    activate_this = os.path.join('%s/bin/activate_this.py' % settings.VENV_DIR)
+    execfile(activate_this, dict(__file__=activate_this))
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openstack_dashboard.settings')
 from django.core.wsgi import get_wsgi_application
 application = get_wsgi_application()
 

--- a/settings.py.example
+++ b/settings.py.example
@@ -1,0 +1,20 @@
+# Kestone URL
+OS_AUTH_URL = 'http://10.1.12.4:35357/v3'
+
+# URL of the DiscoFeed JSON interface produced by the Shibboleth SP
+DISCO_URL = 'https://os.server.name/Shibboleth.sso/DiscoFeed'
+
+# Admin username, usually not to change
+ADMIN_USERNAME = 'admin'
+
+# Admin token to be used to access kestone
+ADMIN_PASSWORD = 'd1410ad0ab162c016171'
+
+# ID of the federation to create in keystone
+FEDERATION_ID = 'Idem'
+
+# ID of the protocol created in keystone, usually not to change
+PROTOCOL_ID = 'saml2'
+
+# ID of the mapping created in keystone, usually not to change
+MAPPING_ID = 'shib'

--- a/update_metadata.py
+++ b/update_metadata.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import urllib
+import urllib2
+import json
+
+def get_url(url, token=None, data=None, info=False, method='GET'):
+    headers = { 'Content-type': 'application/json' }
+
+    if token:
+        headers['X-Auth-Token'] = token
+
+    request = urllib2.Request(url, data, headers)
+    if method != 'GET':
+        request.get_method = lambda: method
+    response = urllib2.urlopen(request)
+
+    if info:
+        return response.info()
+    else:
+        return response.read()
+
+def get_token(config):
+    data = {
+        'auth': {
+            'identity': {
+                'methods': ['password'],
+                'password': {
+                    'user': {
+                        'domain': {
+                            'name': 'Default'
+                        },
+                        'name': config['admin_username'],
+                        'password': config['admin_password']
+                    }
+                }
+            },
+            'scope': {
+                'project': {
+                    'domain': {
+                        'name': 'Default'
+                    },
+                    'name': 'admin'
+                }
+            }
+        }
+    }
+    response = get_url('%s/auth/tokens' % config['os_auth_url'], data=json.dumps(data), info=True)
+    token = response.getheader('X-Subject-Token')
+    if not token:
+        raise Exception('Auth token not created correctly!')
+    return token
+
+def get_new_idps_from_sp(config):
+    response = get_url('%s' % config['disco_url'])
+    response_data = json.loads(response)
+    new_idps = [idp['entityID'] for idp in response_data]
+
+    if len(new_idps) == 0:
+        raise Exception('No IdP could be retrieved from SP discofeed url.')
+
+    return new_idps
+
+def delete_old_idps(config, token):
+    response = get_url('%s/OS-FEDERATION/identity_providers' % config['os_auth_url'], token=token)
+    response_data = json.loads(response)
+    if not response_data['identity_providers']:
+        return
+
+    get_url('%s/OS-FEDERATION/identity_providers/%s' % (config['os_auth_url'], config['federation_id']), token=token, method='DELETE')
+
+    response = get_url('%s/OS-FEDERATION/identity_providers' % config['os_auth_url'], token=token)
+    response_data = json.loads(response)
+    if response_data['identity_providers']:
+        raise Exception('Identity providers not deleted correctly!')
+
+def register_new_idps(config, token, new_idps):
+    data = {
+        'identity_provider': { 
+            'description': 'IdPs of the %s federation' % config['federation_id'],
+            'remote_ids': new_idps, 
+            'enabled': True
+        } 
+    }
+
+    get_url('%s/OS-FEDERATION/identity_providers/%s' % (config['os_auth_url'], config['federation_id']), token=token, data=json.dumps(data), method='PUT')
+
+    response = get_url('%s/OS-FEDERATION/identity_providers' % config['os_auth_url'], token=token)
+    response_data = json.loads(response)
+    if not response_data['identity_providers']:
+        raise Exception('Identity providers not created correctly!')
+
+def add_idp_protocols(config, token):
+    data = {
+        'protocol': {
+            'mapping_id': config['mapping_id']
+        }
+    }
+
+    get_url('%s/OS-FEDERATION/identity_providers/%s/protocols/%s' % (config['os_auth_url'], config['federation_id'], config['protocol_id']), token=token, data=json.dumps(data), method='PUT')
+
+def update_metadata(config):
+    print 'Obtain all new IdPs from Discofeed...',
+    new_idps = get_new_idps_from_sp(config)
+    print ' done!'
+
+    print 'Retrieve a token to be used for authentication...',
+    token = get_token(config)
+    print ' done!'
+
+    print 'Delete previously created IdPs...',
+    delete_old_idps(config, token)
+    print ' done!'
+
+    print 'Register all new IdP entityIDs in the federation module of keystone...',
+    register_new_idps(config, token, new_idps)
+    print ' done!'
+
+    print 'Add the protocol to manage SAML requests...',
+    add_idp_protocols(config, token)
+    print ' done!'
+
+if __name__ == '__main__':
+    update_metadata({
+        'os_auth_url': 'http://10.20.30.49:35357/v3',
+        'disco_url': 'https://os-test.mi.garr.it/Shibboleth.sso/DiscoFeed',
+        'admin_username': 'admin',
+        'admin_password': '391fab406dff4474',
+        'federation_id': 'Idem',
+        'protocol_id': 'saml2',
+        'mapping_id': 'shib',
+    })


### PR DESCRIPTION
I managed to have an OpenStack instance to work correctly in this "federated" way!

I had to make some small modification to the code:
- to make optional the use of venv (as we discussed)
- to manage the case of users without an email address in keystone (a check on whether the object user has the property .email or not)
- added a script to automatize the registration if IdPs in the keystone federation API retrieving list from DiscoFeed of Shibboleth SP
- added description about how to patch django_openstack_auth (if not of the correct version for websso redirect problems)
